### PR TITLE
Integration Test設定を行う

### DIFF
--- a/tic_tac_toe_app/integration_test/app_test.dart
+++ b/tic_tac_toe_app/integration_test/app_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:tic_tac_toe_app/main.dart'; // アプリのエントリーポイント
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized(); // テストバインディングの初期化
+
+  testWidgets('ボタンを押してテキストを変更する', (WidgetTester tester) async {
+    // テスト対象のアプリを起動
+    await tester.pumpWidget(const TicTacToeApp());
+
+    // 初期状態で表示されているテキストを確認
+    expect(find.text('人 vs 人'), findsOneWidget);
+
+    // ボタンをタップして画面遷移を行う
+    await tester.tap(find.text('人 vs 人'));
+    await tester.pumpAndSettle();
+
+    // TicTacToeGame画面に遷移したことを確認します。
+    expect(find.byType(TicTacToeGame), findsOneWidget);
+
+    // 遷移後の画面のisVsComputerプロパティがfalseであることを確認します。
+    final ticTacToeGameWidget = tester.widget<TicTacToeGame>(
+      find.byType(TicTacToeGame),
+    );
+    expect(ticTacToeGameWidget.isVsComputer, isFalse);
+  });
+}

--- a/tic_tac_toe_app/pubspec.yaml
+++ b/tic_tac_toe_app/pubspec.yaml
@@ -36,6 +36,8 @@ dependencies:
   cupertino_icons: ^1.0.8
 
 dev_dependencies:
+  integration_test:
+    sdk: flutter
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
Fixes #6

## Sourceryによる概要

`integration_test`依存関係を追加し、メインアプリフローのエンドツーエンドテストを作成することで、Flutterの統合テストをセットアップしました。

改善点:
- `dev_dependencies`に`integration_test` SDKを追加しました

テスト:
- アプリを起動し、「人 vs 人」ボタンをタップし、`isVsComputer`が`false`に設定された`TicTacToeGame`へのナビゲーションを検証する統合テストを追加しました

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Set up Flutter integration testing by adding the integration_test dependency and creating an end-to-end test for the main app flow

Enhancements:
- Add integration_test SDK to dev_dependencies

Tests:
- Add an integration test that launches the app, taps the '人 vs 人' button, and verifies navigation to TicTacToeGame with isVsComputer set to false

</details>